### PR TITLE
fixed possible IllegalArgumentException for minecraft 1.20

### DIFF
--- a/plugin/src/main/java/ru/spliterash/musicbox/utils/YamlSupportUtils.java
+++ b/plugin/src/main/java/ru/spliterash/musicbox/utils/YamlSupportUtils.java
@@ -11,11 +11,13 @@ import java.lang.reflect.Constructor;
 @UtilityClass
 public class YamlSupportUtils {
     @SneakyThrows
+    @SuppressWarnings("JavaReflectionMemberAccess")
     public static CustomClassLoaderConstructor createCustomClassLoaderConstructor() {
-        Constructor<?> constructor = CustomClassLoaderConstructor.class.getConstructors()[1];
-        if (constructor.getParameterCount() == 2)
+        try {
+            Constructor<?> constructor = CustomClassLoaderConstructor.class.getConstructor(Class.class, ClassLoader.class);
             return (CustomClassLoaderConstructor) constructor.newInstance(MusicBoxConfig.class, MusicBoxConfig.class.getClassLoader());
-        else
+        } catch (NoSuchMethodException e){
             return new CustomClassLoaderConstructor(MusicBoxConfig.class, MusicBoxConfig.class.getClassLoader(), new LoaderOptions());
+        }
     }
 }


### PR DESCRIPTION
У меня на сервере возникла проблема. При загрузке плагина вылетал IllegalArgumentException, при этом на дебаг версии сервера такого не происходило. Оказалось что метод Class#getConstructors() не обязательно возвращает конструкторы в том порядке, в котором они были объявлены в классе, и скорее всего порядок этого массива может варьироваться от используемой виртуальной машины: [StackOverflow](https://stackoverflow.com/questions/34289801/how-is-the-order-of-the-array-what-class-getconstructors-returns-in-java)

Я запилил фикс, который ищет нужный конструктор по параметрам, и проверил на 1.19 со старым snakeyaml и на 1.20 продакшн и дебаг сервере, где уже стоял snakeyaml 2.0. Во всех случаях плагин грузился корректно.