### PR TITLE
add `/musicbox give` command

### DIFF
--- a/plugin/src/main/java/ru/spliterash/musicbox/Lang.java
+++ b/plugin/src/main/java/ru/spliterash/musicbox/Lang.java
@@ -92,6 +92,10 @@ public enum Lang {
             "&b/musicbox get (name)&6- Open get disc GUI or get disc with name",
             "&b/musicbox get (name)&6- Открыть инвентарь получения дисков или получить диск с именем"
     ),
+    COMMAND_HELP_GIVE(
+            "&b/musicbox give [player] [name]&6- Give disc with name to the player",
+            "&b/musicbox give [player] [name]&6- Передача диска с именем игрока"
+    ),
     COMMAND_HELP(
             Arrays.asList(
                     "&b/musicbox &6- Open music gui",

--- a/plugin/src/main/java/ru/spliterash/musicbox/commands/MusicBoxExecutor.java
+++ b/plugin/src/main/java/ru/spliterash/musicbox/commands/MusicBoxExecutor.java
@@ -21,6 +21,7 @@ public class MusicBoxExecutor implements TabExecutor {
     public MusicBoxExecutor() {
         subs.put("shop", new ShopExecutor());
         subs.put("get", new GetExecutor());
+        subs.put("give", new GiveExecutor());
         subs.put("playlist", new PlaylistExecutor(this));
         subs.put("play", new PlayExecutor(this));
         subs.put("shutup", new ShutUp(this));
@@ -66,6 +67,9 @@ public class MusicBoxExecutor implements TabExecutor {
         if (sender.hasPermission("musicbox.get")) {
             sender.sendMessage(Lang.COMMAND_HELP_GET.toString());
         }
+        if (sender.hasPermission("musicbox.give")) {
+            sender.sendMessage(Lang.COMMAND_HELP_GIVE.toString());
+        }
         if (sender.hasPermission("musicbox.admin")) {
             sender.sendMessage(Lang.ADMIN_HELP.toArray());
         }
@@ -87,6 +91,8 @@ public class MusicBoxExecutor implements TabExecutor {
                 tabComplete.add("shop");
             if (player.hasPermission("musicbox.get"))
                 tabComplete.add("get");
+            if (player.hasPermission("musicbox.give"))
+                tabComplete.add("give");
             if (player.hasPermission("musicbox.admin")) {
                 tabComplete.add("admin");
                 tabComplete.add("shutup");

--- a/plugin/src/main/java/ru/spliterash/musicbox/commands/subcommands/GiveExecutor.java
+++ b/plugin/src/main/java/ru/spliterash/musicbox/commands/subcommands/GiveExecutor.java
@@ -1,0 +1,61 @@
+package ru.spliterash.musicbox.commands.subcommands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import ru.spliterash.musicbox.Lang;
+import ru.spliterash.musicbox.commands.SubCommand;
+import ru.spliterash.musicbox.gui.GUIActions;
+import ru.spliterash.musicbox.players.PlayerWrapper;
+import ru.spliterash.musicbox.song.MusicBoxSong;
+import ru.spliterash.musicbox.song.MusicBoxSongManager;
+import ru.spliterash.musicbox.utils.ArrayUtils;
+import ru.spliterash.musicbox.utils.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class GiveExecutor implements SubCommand {
+    @Override
+    public String getPex() {
+        return "musicbox.give";
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length != 2) {
+            sender.sendMessage(Lang.COMMAND_HELP_GIVE.toString());
+        } else {
+            Player p = Bukkit.getPlayer(args[0]);
+            if (p == null) {
+                sender.sendMessage(Lang.PLAYER_OFLLINE.toString("{player}", args[0]));
+                return;
+            }
+            String songName = args[1].replace('_', ' ');
+            MusicBoxSong song = MusicBoxSongManager.findByName(songName).orElse(null);
+            if (song != null) {
+                GUIActions.giveDisc(PlayerWrapper.getInstance(p), song);
+            } else {
+                sender.sendMessage(Lang.SONG_NOT_FOUND.toString());
+            }
+        }
+    }
+
+    @Override
+    public List<String> tabComplete(Player player, String[] args) {
+        if (args.length == 1) {
+            return null;
+        }
+        if (args.length == 2) {
+            Stream<String> stream = MusicBoxSongManager
+                    .getRootContainer()
+                    .getAllSongs()
+                    .stream()
+                    .map(MusicBoxSong::getName)
+                    .map(s -> s.replace(' ', '_'));
+            return StringUtils.tabCompletePrepare(ArrayUtils.removeFirst(String.class, args), stream);
+        }
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
I thought add a `give` command is necessary.

e.g.

I want to make a disc shop via other plugin. But MusicBox has just only one `get` command and the `other` plugin does not support `execute as Operator` (also execute command as an operator is a dangerous action). I can't do this without `give` command.

With `give` command, I just need to execute the command as console. Most of shop or menu plugin can do this with placeholder.
